### PR TITLE
Upgrade terraform, tflint, & tflint-ruleset-aws

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,19 +43,19 @@ RUN     curl -sL -o terraform-docs.tar.gz https://github.com/terraform-docs/terr
         mv terraform-docs ${BINDIR}/ && \
         rm -rf *
 
-ARG     TERRAFORM_VERSION=1.4.5
+ARG     TERRAFORM_VERSION=1.5.5
 RUN     curl -sL -o terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
         unzip terraform.zip && \
         mv terraform ${BINDIR} && \
         chmod +x ${BINDIR}/terraform && \
         rm -rf *
 
-ARG     TFLINT_VERSION=0.46.0
+ARG     TFLINT_VERSION=0.47.0
 RUN     curl -sL -o tflint.zip https://github.com/terraform-linters/tflint/releases/download/v"${TFLINT_VERSION}"/tflint_linux_amd64.zip && \
         unzip tflint.zip -d ${BINDIR}/ && \
         rm -rf *
 
-ARG     TFLINT_RULESET_AWS_VERSION=0.22.1
+ARG     TFLINT_RULESET_AWS_VERSION=0.26.0
 RUN     curl -sL -o tflint-ruleset-aws.zip https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v"${TFLINT_RULESET_AWS_VERSION}"/tflint-ruleset-aws_linux_amd64.zip && \
         unzip tflint-ruleset-aws.zip -d ~/.tflint.d/plugins && \
         rm tflint-ruleset-aws.zip


### PR DESCRIPTION
I will probably not upgrade this past terraform 1.5.5, because licensing.